### PR TITLE
Fix webcam capture

### DIFF
--- a/emotions.py
+++ b/emotions.py
@@ -33,7 +33,6 @@ emotion_window = []
 # starting video streaming
 
 cv2.namedWindow('window_frame')
-video_capture = cv2.VideoCapture(0)
 
 # Select video or webcam feed
 cap = None


### PR DESCRIPTION
When `USE_WEBCAM` is set to true the instruction `cv2.VideoCapture(0)` is run twice, which leads to it blocking the program and causing it to freeze.

This PR fixes that issue by removing the initial call, as it is dead code (it is assigned to a variable that is never used).